### PR TITLE
Add reference to the form format definition. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ _onChange: function() {
     });
 }
 ```
+
+# Form format
+
+React-schema-form implements the json-schema-form format.
+The documentation for that format is located at the [json-schema-form wiki](https://github.com/json-schema-form/json-schema-form/wiki/Documentation).
+
 # Examples
 
 There are some simple forms in the demo to show how each fields to be rendered.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ _onChange: function() {
 
 # Form format
 
-React-schema-form implements the json-schema-form format.
+React-schema-form implements the form format as defined by the json-schema-form standard.
+
 The documentation for that format is located at the [json-schema-form wiki](https://github.com/json-schema-form/json-schema-form/wiki/Documentation).
 
 # Examples


### PR DESCRIPTION
Hi, 
I added a reference to the form format documentation. 
It is not complete yet, but it is better that nothing.
It seems like the form format is a stumbling block for many users, and a pretty well isolated one at that.
Perhaps one should try and create a central place for question WRT to the format itself, so that most question regarding it goes there, and not to the implementations?
