### PR TITLE
Fix(Number): don't call onChangeValidate twice

### DIFF
--- a/src/Number.js
+++ b/src/Number.js
@@ -35,9 +35,7 @@ class Number extends React.Component {
             this.props.onChangeValidate(e);
         } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
-
         }
-        this.props.onChangeValidate(e);
     }
 
     render() {


### PR DESCRIPTION
If target value is numeric, call onChangeValidate callback, otherwise silently reset to last successful value