### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,11 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.6",
     "material-ui": "^0.16.1",
-    "object-assign": "^4.0.1",
     "objectpath": "^1.2.1",
-    "react": "^15.3.2",
-    "react-dom": "^15.0.0",
-    "react-tap-event-plugin": "^1.0.0",
     "tv4": "^1.2.7"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^7.1.0",
     "babel-jest": "^16.0.0",
@@ -56,13 +53,18 @@
     "less-loader": "^2.2.3",
     "react-ace": "4.0.0",
     "react-addons-test-utils": "^15.3.2",
+    "react-dom": "^15.0.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-schema-form-rc-select": "^0.2.0",
     "react-select": "^1.0.0-rc.2",
+    "react-tap-event-plugin": "^1.0.0",
     "rimraf": "^2.5.4",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.3",
     "webpack-dev-server": "^1.16.2"
+  },
+  "peerDependencies": {
+    "react": "^15.3.2"
   },
   "scripts": {
     "lint": "eslint src",


### PR DESCRIPTION
- Remove object-assign because unused
- Move react to peerDependencies
- Move react-dom and react-tap-event-plugin to devDependencies
- Add babel-cli to devDependencies because required by prepublish script