### PR TITLE
Adding htmlClass from the json-schema-form specification

### DIFF
--- a/lib/Checkbox.js
+++ b/lib/Checkbox.js
@@ -43,16 +43,20 @@ var Checkbox2 = function (_React$Component) {
         value: function render() {
             var _this2 = this;
 
-            return _react2.default.createElement(_Checkbox2.default, {
-                name: this.props.form.key.slice(-1)[0],
-                value: this.props.form.key.slice(-1)[0],
-                defaultChecked: this.props.value || false,
-                label: this.props.form.title,
-                disabled: this.props.form.readonly,
-                onCheck: function onCheck(e, checked) {
-                    _this2.props.onChangeValidate(e);
-                }
-            });
+            return _react2.default.createElement(
+                'div',
+                { className: this.props.form.className },
+                _react2.default.createElement(_Checkbox2.default, {
+                    name: this.props.form.key.slice(-1)[0],
+                    value: this.props.form.key.slice(-1)[0],
+                    defaultChecked: this.props.value || false,
+                    label: this.props.form.title,
+                    disabled: this.props.form.readonly,
+                    onCheck: function onCheck(e, checked) {
+                        _this2.props.onChangeValidate(e);
+                    }
+                })
+            );
         }
     }]);
 

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -58,7 +58,7 @@ var Date = function (_React$Component) {
         value: function render() {
             return _react2.default.createElement(
                 'div',
-                { style: { width: '100%', display: 'block' } },
+                { style: { width: '100%', display: 'block' }, className: this.props.form.htmlClass },
                 _react2.default.createElement(_DatePicker2.default, {
                     mode: 'landscape',
                     autoOk: true,

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -74,16 +74,20 @@ var Number = function (_React$Component) {
     }, {
         key: 'render',
         value: function render() {
-            return _react2.default.createElement(_TextField2.default, {
-                type: this.props.form.type,
-                floatingLabelText: this.props.form.title,
-                hintText: this.props.form.placeholder,
-                errorText: this.props.error,
-                onChange: this.preValidationCheck,
-                defaultValue: this.state.lastSuccessfulValue,
-                ref: 'numberField',
-                disabled: this.props.form.readonly,
-                style: this.props.form.style || { width: '100%' } });
+            return _react2.default.createElement(
+                'div',
+                { className: this.props.form.htmlClass },
+                _react2.default.createElement(_TextField2.default, {
+                    type: this.props.form.type,
+                    floatingLabelText: this.props.form.title,
+                    hintText: this.props.form.placeholder,
+                    errorText: this.props.error,
+                    onChange: this.preValidationCheck,
+                    defaultValue: this.state.lastSuccessfulValue,
+                    ref: 'numberField',
+                    disabled: this.props.form.readonly,
+                    style: this.props.form.style || { width: '100%' } })
+            );
         }
     }]);
 

--- a/lib/Radios.js
+++ b/lib/Radios.js
@@ -60,7 +60,7 @@ var Radios = function (_React$Component) {
 
             return _react2.default.createElement(
                 'span',
-                null,
+                { className: this.props.form.htmlClass },
                 _react2.default.createElement(
                     'label',
                     { className: 'control-lable' },

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -68,14 +68,18 @@ var Select = function (_React$Component) {
             });
 
             return _react2.default.createElement(
-                _SelectField2.default,
-                {
-                    value: this.state.currentValue,
-                    floatingLabelText: this.props.form.title,
-                    disabled: this.props.form.readonly,
-                    onChange: this.onSelected,
-                    fullWidth: true },
-                menuItems
+                'div',
+                { className: this.props.form.htmlClass },
+                _react2.default.createElement(
+                    _SelectField2.default,
+                    {
+                        value: this.state.currentValue,
+                        floatingLabelText: this.props.form.title,
+                        disabled: this.props.form.readonly,
+                        onChange: this.onSelected,
+                        fullWidth: true },
+                    menuItems
+                )
             );
         }
     }]);

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -44,7 +44,7 @@ var Text = function (_React$Component) {
             //console.log('Text props', this.props.form.readonly);
             return _react2.default.createElement(
                 'div',
-                null,
+                { className: this.props.form.htmlClass },
                 _react2.default.createElement(_TextField2.default, {
                     type: this.props.form.type,
                     floatingLabelText: this.props.form.title,

--- a/lib/TextArea.js
+++ b/lib/TextArea.js
@@ -45,7 +45,7 @@ var TextArea = function (_React$Component) {
             //console.log('TextArea', this.props.form);
             return _react2.default.createElement(
                 'div',
-                null,
+                { className: this.props.form.htmlClass },
                 _react2.default.createElement(_TextField2.default, {
                     type: this.props.form.type,
                     floatingLabelText: this.props.form.title,

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -8,14 +8,16 @@ import Checkbox from 'material-ui/Checkbox';
 class Checkbox2 extends React.Component {
     render() {
         return (
-            <Checkbox
-                name={this.props.form.key.slice(-1)[0]}
-                value={this.props.form.key.slice(-1)[0]}
-                defaultChecked={this.props.value || false}
-                label={this.props.form.title}
-                disabled={this.props.form.readonly}
-                onCheck={(e, checked) => {this.props.onChangeValidate(e)}}
-                />
+            <div className={this.props.form.className}>
+                <Checkbox
+                    name={this.props.form.key.slice(-1)[0]}
+                    value={this.props.form.key.slice(-1)[0]}
+                    defaultChecked={this.props.value || false}
+                    label={this.props.form.title}
+                    disabled={this.props.form.readonly}
+                    onCheck={(e, checked) => {this.props.onChangeValidate(e)}}
+                    />
+             </div>
         );
     }
 }

--- a/src/Date.js
+++ b/src/Date.js
@@ -25,7 +25,7 @@ class Date extends React.Component {
 
     render() {
         return (
-            <div style={{width: '100%', display: 'block'}}>
+            <div style={{width: '100%', display: 'block'}} className={this.props.form.htmlClass}>
                 <DatePicker
                     mode={'landscape'}
                     autoOk={true}

--- a/src/Number.js
+++ b/src/Number.js
@@ -40,16 +40,18 @@ class Number extends React.Component {
 
     render() {
         return (
-            <TextField
-                type={this.props.form.type}
-                floatingLabelText={this.props.form.title}
-                hintText={this.props.form.placeholder}
-                errorText={this.props.error}
-                onChange={this.preValidationCheck}
-                defaultValue={this.state.lastSuccessfulValue}
-                ref="numberField"
-                disabled={this.props.form.readonly}
-                style={this.props.form.style || {width: '100%'}}/>
+            <div className={this.props.form.htmlClass}>
+                <TextField
+                    type={this.props.form.type}
+                    floatingLabelText={this.props.form.title}
+                    hintText={this.props.form.placeholder}
+                    errorText={this.props.error}
+                    onChange={this.preValidationCheck}
+                    defaultValue={this.state.lastSuccessfulValue}
+                    ref="numberField"
+                    disabled={this.props.form.readonly}
+                    style={this.props.form.style || {width: '100%'}}/>
+            </div>
         );
     }
 }

--- a/src/Radios.js
+++ b/src/Radios.js
@@ -20,7 +20,7 @@ class Radios extends React.Component {
         }.bind(this));
 
         return (
-            <span>
+            <span className={this.props.form.htmlClass}>
               <label className="control-lable">{this.props.form.title}</label>
               <RadioButtonGroup defaultSelected={this.props.value} name={this.props.form.title} onChange={this.props.onChangeValidate}>
                   {items}

--- a/src/Select.js
+++ b/src/Select.js
@@ -34,15 +34,17 @@ class Select extends React.Component {
         ));
 
         return (
-            <SelectField
-                value={this.state.currentValue}
-                floatingLabelText={this.props.form.title}
-                disabled={this.props.form.readonly}
-                onChange={this.onSelected}
-                fullWidth={true} >
+            <div className={this.props.form.htmlClass}>
+                <SelectField
+                    value={this.state.currentValue}
+                    floatingLabelText={this.props.form.title}
+                    disabled={this.props.form.readonly}
+                    onChange={this.onSelected}
+                    fullWidth={true} >
 
-                {menuItems}
-            </SelectField>
+                    {menuItems}
+                </SelectField>
+            </div>
         );
     }
 }

--- a/src/Text.js
+++ b/src/Text.js
@@ -9,7 +9,7 @@ class Text extends React.Component {
     render() {
         //console.log('Text props', this.props.form.readonly);
         return (
-            <div>
+            <div className={this.props.form.htmlClass}>
                 <TextField
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -11,7 +11,7 @@ class TextArea extends React.Component {
         // FIXME: Obviously fix rowsMax eventually..
         //console.log('TextArea', this.props.form);
         return (
-            <div>
+            <div className={this.props.form.htmlClass}>
                 <TextField
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}


### PR DESCRIPTION
Hey All!

We have a use-case where we need to be able to apply classNames, and found a reference to `htmlClass` in the spec: https://github.com/json-schema-form/json-schema-form/wiki/Documentation#standard-options

Because material-ui doesn't really expose `label` and `field` className props, I couldn't introduce the spec for classes fully, but we can at least use the `htmlClass` one on the top level.

**Notes about the implementation**
There were some instances where the MUI component wasn't being wrapped by an element (and MUI didn't expose a wrapper className prop), in these instances I have introduced a wrapper element. Let me know if you think there will be consequences for layout in projects. I looked through the examples with these changes and the layout seemed to be intact.

There is an alternate implementation where we could use logic to check if there is `this.props.form.htmlClass` being passed, and only then is the MUI component wrapped.

If you have any changes you'd like made before merging, feel free to give feedback.

Thanks!