### PR TITLE
Adding top-level className for better framework support

### DIFF
--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -126,7 +126,7 @@ var SchemaForm = function (_React$Component) {
 
             return _react2.default.createElement(
                 'div',
-                { style: { width: '100%' }, className: 'SchemaForm' },
+                { style: { width: '100%' }, className: 'SchemaForm ' + this.props.className },
                 forms
             );
         }

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -66,7 +66,7 @@ class SchemaForm extends React.Component {
         }.bind(this));
 
         return (
-            <div style={{width: '100%'}} className='SchemaForm'>{forms}</div>
+            <div style={{width: '100%'}} className={'SchemaForm ' + this.props.className}>{forms}</div>
         );
     }
 }


### PR DESCRIPTION
Hey Again,

Sorry I didn't think of this for my previous PR, but as I've started implementation using the new version bump, I've realised that there isn't a top-level className prop.

This makes it possible for people using CSS frameworks like bootstrap or bulma to apply their wrapper classes ('col-xs-12' or 'colums') to style the forms that get output, in combination with my previous PR.

Thanks for getting back to me and releasing so quickly on my previous PR!

