### PR TITLE
Load model into form

### DIFF
--- a/example/data/date.json
+++ b/example/data/date.json
@@ -9,7 +9,7 @@
             },
             "date": {
                 "title": "Date",
-                "type": "date"
+                "type": "object"
             }
         },
         "required": ["name", "date"]

--- a/lib/ComposedComponent.js
+++ b/lib/ComposedComponent.js
@@ -33,7 +33,7 @@ var _default = function _default(ComposedComponent) {
             var _this = _possibleConstructorReturn(this, (_class.__proto__ || Object.getPrototypeOf(_class)).call(this, props));
 
             _this.onChangeValidate = _this.onChangeValidate.bind(_this);
-            var value = _this.defaultValue();
+            var value = _this.defaultValue(_this.props);
             var validationResult = utils.validate(_this.props.form, value);
             _this.state = {
                 value: value,
@@ -44,11 +44,15 @@ var _default = function _default(ComposedComponent) {
         }
 
         _createClass(_class, [{
-            key: 'componentDidMount',
-            value: function componentDidMount() {
-                if (typeof this.state.value !== 'undefined') {
-                    this.props.onChange(this.props.form.key, this.state.value);
-                }
+            key: 'componentWillReceiveProps',
+            value: function componentWillReceiveProps(nextProps) {
+                var value = this.defaultValue(nextProps);
+                var validationResult = utils.validate(nextProps.form, value);
+                this.setState({
+                    value: value,
+                    valid: !!(validationResult.valid || !value),
+                    error: !validationResult.valid && value ? validationResult.error.message : null
+                });
             }
 
             /**
@@ -91,27 +95,27 @@ var _default = function _default(ComposedComponent) {
             }
         }, {
             key: 'defaultValue',
-            value: function defaultValue() {
+            value: function defaultValue(props) {
                 // check if there is a value in the model, if there is, display it. Otherwise, check if
                 // there is a default value, display it.
                 //console.log('Text.defaultValue key', this.props.form.key);
                 //console.log('Text.defaultValue model', this.props.model);
-                var value = utils.selectOrSet(this.props.form.key, this.props.model);
+                var value = utils.selectOrSet(props.form.key, props.model);
                 //console.log('Text defaultValue value = ', value);
 
                 // check if there is a default value
-                if (!value && this.props.form['default']) {
-                    value = this.props.form['default'];
+                if (!value && props.form['default']) {
+                    value = props.form['default'];
                 }
 
-                if (!value && this.props.form.schema && this.props.form.schema['default']) {
-                    value = this.props.form.schema['default'];
+                if (!value && props.form.schema && props.form.schema['default']) {
+                    value = props.form.schema['default'];
                 }
 
                 // Support for Select
                 // The first value in the option will be the default.
-                if (!value && this.props.form.titleMap && this.props.form.titleMap[0].value) {
-                    value = this.props.form.titleMap[0].value;
+                if (!value && props.form.titleMap && props.form.titleMap[0].value) {
+                    value = props.form.titleMap[0].value;
                 }
                 //console.log('value', value);
                 return value;

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -49,6 +49,13 @@ var Number = function (_React$Component) {
     }
 
     _createClass(Number, [{
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+            this.setState({
+                lastSuccessfulValue: nextProps.value
+            });
+        }
+    }, {
         key: 'isNumeric',
         value: function isNumeric(n) {
             return !isNaN(parseFloat(n)) && isFinite(n);
@@ -83,7 +90,7 @@ var Number = function (_React$Component) {
                     hintText: this.props.form.placeholder,
                     errorText: this.props.error,
                     onChange: this.preValidationCheck,
-                    defaultValue: this.state.lastSuccessfulValue,
+                    value: this.state.lastSuccessfulValue,
                     ref: 'numberField',
                     disabled: this.props.form.readonly,
                     style: this.props.form.style || { width: '100%' } })

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -51,7 +51,7 @@ var Text = function (_React$Component) {
                     hintText: this.props.form.placeholder,
                     errorText: this.props.error,
                     onChange: this.props.onChangeValidate,
-                    defaultValue: this.props.value,
+                    value: this.props.value,
                     disabled: this.props.form.readonly,
                     style: this.props.form.style || { width: '100%' } })
             );

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -12,7 +12,7 @@ class Checkbox2 extends React.Component {
                 <Checkbox
                     name={this.props.form.key.slice(-1)[0]}
                     value={this.props.form.key.slice(-1)[0]}
-                    defaultChecked={this.props.value || false}
+                    checked={this.props.value || false}
                     label={this.props.form.title}
                     disabled={this.props.form.readonly}
                     onCheck={(e, checked) => {this.props.onChangeValidate(e)}}

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -33,7 +33,9 @@ export default ComposedComponent => class extends React.Component {
     onChangeValidate(e) {
         //console.log('onChangeValidate e', e);
         let value = null;
-        if (this.props.form.schema.type === 'integer' || this.props.form.schema.type === 'number') {
+        switch(this.props.form.schema.type) {
+          case 'integer':
+          case 'number':
             if (e.target.value.indexOf('.') == -1) {
                 value = parseInt(e.target.value);
             } else {
@@ -43,13 +45,15 @@ export default ComposedComponent => class extends React.Component {
             if (isNaN(value)) {
               value = undefined;
             }
-
-
-        } else if(this.props.form.schema.type === 'boolean') {
+            break;
+          case 'boolean':
             value = e.target.checked;
-        } else if(this.props.form.schema.type === 'date' || this.props.form.schema.type === 'array') {
+            break;
+          case 'date':
+          case 'array':
             value = e;
-        } else { // string
+            break
+          default:
             value = e.target.value;
         }
         //console.log('onChangeValidate this.props.form, value', this.props.form, value);

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -7,7 +7,7 @@ export default ComposedComponent => class extends React.Component {
     constructor(props) {
         super(props);
         this.onChangeValidate = this.onChangeValidate.bind(this);
-        let value = this.defaultValue();
+        let value = this.defaultValue(this.props);
         let validationResult = utils.validate(this.props.form, value);
         this.state = {
             value: value,
@@ -16,10 +16,14 @@ export default ComposedComponent => class extends React.Component {
         };
     }
 
-    componentDidMount() {
-        if (typeof this.state.value !== 'undefined') {
-            this.props.onChange(this.props.form.key, this.state.value);
-        }
+    componentWillReceiveProps(nextProps) {
+      let value = this.defaultValue(nextProps);
+      let validationResult = utils.validate(nextProps.form, value);
+      this.setState({
+        value: value,
+        valid: !!(validationResult.valid || !value),
+        error: !validationResult.valid && value ? validationResult.error.message : null
+      });
     }
 
     /**
@@ -59,27 +63,27 @@ export default ComposedComponent => class extends React.Component {
         this.props.onChange(this.props.form.key, value);
     }
 
-    defaultValue() {
+    defaultValue(props) {
         // check if there is a value in the model, if there is, display it. Otherwise, check if
         // there is a default value, display it.
         //console.log('Text.defaultValue key', this.props.form.key);
         //console.log('Text.defaultValue model', this.props.model);
-        let value = utils.selectOrSet(this.props.form.key, this.props.model);
+        let value = utils.selectOrSet(props.form.key, props.model);
         //console.log('Text defaultValue value = ', value);
 
         // check if there is a default value
-        if(!value && this.props.form['default']) {
-            value = this.props.form['default'];
+        if(!value && props.form['default']) {
+            value = props.form['default'];
         }
 
-        if(!value && this.props.form.schema && this.props.form.schema['default']) {
-            value = this.props.form.schema['default'];
+        if(!value && props.form.schema && props.form.schema['default']) {
+            value = props.form.schema['default'];
         }
 
         // Support for Select
         // The first value in the option will be the default.
-        if(!value && this.props.form.titleMap && this.props.form.titleMap[0].value) {
-            value = this.props.form.titleMap[0].value;
+        if(!value && props.form.titleMap && props.form.titleMap[0].value) {
+            value = props.form.titleMap[0].value;
         }
         //console.log('value', value);
         return value;

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -49,7 +49,7 @@ export default ComposedComponent => class extends React.Component {
           case 'boolean':
             value = e.target.checked;
             break;
-          case 'date':
+          case 'object':
           case 'array':
             value = e;
             break

--- a/src/Date.js
+++ b/src/Date.js
@@ -24,6 +24,11 @@ class Date extends React.Component {
     }
 
     render() {
+        var value = null;
+        if (this.props && this.props.value) {
+            value = this.props.value;
+        }
+
         return (
             <div style={{width: '100%', display: 'block'}} className={this.props.form.htmlClass}>
                 <DatePicker
@@ -34,6 +39,7 @@ class Date extends React.Component {
                     onChange={this.onDatePicked}
                     onShow={null}
                     onDismiss={null}
+                    value={value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}/>
 

--- a/src/Number.js
+++ b/src/Number.js
@@ -19,6 +19,12 @@ class Number extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+      this.setState({
+        lastSuccessfulValue: nextProps.value
+      });
+    }
+
     isNumeric(n) {
         return !isNaN(parseFloat(n)) && isFinite(n);
     }
@@ -47,7 +53,7 @@ class Number extends React.Component {
                     hintText={this.props.form.placeholder}
                     errorText={this.props.error}
                     onChange={this.preValidationCheck}
-                    defaultValue={this.state.lastSuccessfulValue}
+                    value={this.state.lastSuccessfulValue}
                     ref="numberField"
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}/>

--- a/src/Text.js
+++ b/src/Text.js
@@ -16,7 +16,7 @@ class Text extends React.Component {
                     hintText={this.props.form.placeholder}
                     errorText={this.props.error}
                     onChange={this.props.onChangeValidate}
-                    defaultValue={this.props.value}
+                    value={this.props.value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}} />
             </div>

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -18,7 +18,7 @@ class TextArea extends React.Component {
                     hintText={this.props.form.placeholder}
                     onChange={this.props.onChangeValidate}
                     errorText={this.props.error}
-                    defaultValue={this.props.value}
+                    value={this.props.value}
                     multiLine={true}
                     rows={this.props.form.rows}
                     rowsMax={this.props.form.rowsMax}


### PR DESCRIPTION
Followed up on some work that @agrishun had on his fork, this allows components to receive properties and update their values, such as when the user loads the model from an external source.

Rather than using ````defaultValue```, this sets the ```value``` of the material-ui components - making them controlled components

The dates must be ```objects``` in the schema, which is problematic, open to suggestions. 