### PR TITLE
Fix issue with enum not being able to display because of an undefined…

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -43,7 +43,7 @@ var Select = function (_React$Component) {
 
         _this.onSelected = _this.onSelected.bind(_this);
         _this.state = {
-            currentValue: _this.props.model[_this.props.form.key] || (_this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : '')
+            currentValue: _this.props.model !== undefined ? _this.props.model[_this.props.form.key] : (_this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : '')
         };
         return _this;
     }


### PR DESCRIPTION
… _this.props.model: https://github.com/networknt/react-schema-form/issues/42

The above mentioned issue is due to `_this.props.model` being undefined and trying to access a key from it. The proposed fix just does a check to make sure that `_this.props.model` is not undefined before trying to access an attribute from it.