### PR TITLE
Refresh stateful form inputs on external model update

### DIFF
--- a/lib/Array.js
+++ b/lib/Array.js
@@ -97,6 +97,15 @@ var Array = function (_React$Component) {
     }
 
     _createClass(Array, [{
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+            if (nextProps.model) {
+                this.setState({
+                    model: _utils2.default.selectOrSet(nextProps.form.key, nextProps.model) || []
+                });
+            }
+        }
+    }, {
         key: 'componentDidMount',
         value: function componentDidMount() {
             // Always start with one empty form unless configured otherwise.

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -52,9 +52,9 @@ var Select = function (_React$Component) {
         key: 'componentWillReceiveProps',
         value: function componentWillReceiveProps(nextProps) {
             if (nextProps.model) {
-                this.state = {
+                this.setState({
                     currentValue: nextProps.model[nextProps.form.key] || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
-                };
+                });
             }
         }
     }, {

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -43,12 +43,21 @@ var Select = function (_React$Component) {
 
         _this.onSelected = _this.onSelected.bind(_this);
         _this.state = {
-            currentValue: _this.props.model !== undefined ? _this.props.model[_this.props.form.key] : (_this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : '')
+            currentValue: _this.props.model[_this.props.form.key] || (_this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : '')
         };
         return _this;
     }
 
     _createClass(Select, [{
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+            if (nextProps.model) {
+                this.state = {
+                    currentValue: nextProps.model[nextProps.form.key] || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
+                };
+            }
+        }
+    }, {
         key: 'onSelected',
         value: function onSelected(event, selectedIndex, menuItem) {
 

--- a/src/Array.js
+++ b/src/Array.js
@@ -26,9 +26,17 @@ class Array extends React.Component {
         // we have the model here for the entire form, get the model for this array only
         // and add to the state. if is empty, add an entry by calling onAppend directly.
         this.state = {
-            model:  utils.selectOrSet(this.props.form.key, this.props.model) || []
+            model: utils.selectOrSet(this.props.form.key, this.props.model) || []
         };
         //console.log('constructor', this.props.form.key, this.props.model, this.state.model);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.model) {
+            this.setState({
+                model: utils.selectOrSet(nextProps.form.key, nextProps.model) || []
+            });
+        }
     }
 
     componentDidMount() {

--- a/src/Select.js
+++ b/src/Select.js
@@ -17,6 +17,15 @@ class Select extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+      if (nextProps.model) {
+        this.state = {
+          currentValue: nextProps.model[nextProps.form.key]
+          || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
+        };
+      }
+    }
+
     onSelected(event, selectedIndex, menuItem) {
 
         this.setState({

--- a/src/Select.js
+++ b/src/Select.js
@@ -18,12 +18,12 @@ class Select extends React.Component {
     }
 
     componentWillReceiveProps(nextProps) {
-      if (nextProps.model) {
-        this.state = {
-          currentValue: nextProps.model[nextProps.form.key]
-          || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
-        };
-      }
+        if (nextProps.model) {
+            this.setState({
+                currentValue: nextProps.model[nextProps.form.key]
+                || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
+            });
+        }
     }
 
     onSelected(event, selectedIndex, menuItem) {


### PR DESCRIPTION
_Refers to issue: https://github.com/networknt/react-schema-form/issues/6_

**Description:** Added componentWillReceiveProps lifecycle hook to stateful components

After checking every field components: 
- Number already implements this solution
- I have updated Select and Array to update their internal state when receiving new props
- Other components do not hold an internal state and thus do not need an update.

