### PR TITLE
Fix `cannot read property` error when using an enum in an object

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -43,7 +43,7 @@ var Select = function (_React$Component) {
 
         _this.onSelected = _this.onSelected.bind(_this);
         _this.state = {
-            currentValue: _this.props.model[_this.props.form.key] || (_this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : '')
+            currentValue: _this.props.model !== undefined ? _this.props.model[_this.props.form.key] : _this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : ''
         };
         return _this;
     }

--- a/src/Select.js
+++ b/src/Select.js
@@ -12,8 +12,7 @@ class Select extends React.Component {
         super(props);
         this.onSelected = this.onSelected.bind(this);
         this.state = {
-            currentValue: this.props.model[this.props.form.key]
-            || (this.props.form.titleMap != null ? this.props.form.titleMap[0].value : '')
+            currentValue: this.props.model !== undefined ? this.props.model[this.props.form.key] : (this.props.form.titleMap != null ? this.props.form.titleMap[0].value : '')
         };
     }
 


### PR DESCRIPTION
The fix applied in https://github.com/networknt/react-schema-form/pull/60
(e53233d27371d474e94b09094c05d40f226f7224) was applied to the
compiled version, rather than the source.
It was then overwritten by 53060fbc8663f7709f112d974f3cc4830dfe22c1.

This fix is applied to the source.

Closes https://github.com/networknt/react-schema-form/issues/42