### PR TITLE
Fix Select when it is in an array

### DIFF
--- a/lib/Select.js
+++ b/lib/Select.js
@@ -42,8 +42,9 @@ var Select = function (_React$Component) {
         var _this = _possibleConstructorReturn(this, (Select.__proto__ || Object.getPrototypeOf(Select)).call(this, props));
 
         _this.onSelected = _this.onSelected.bind(_this);
+        var possibleValue = _this.getModelKey(_this.props.model, _this.props.form.key);
         _this.state = {
-            currentValue: _this.props.model !== undefined ? _this.props.model[_this.props.form.key] : _this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : ''
+            currentValue: _this.props.model !== undefined && possibleValue ? possibleValue : _this.props.form.titleMap != null ? _this.props.form.titleMap[0].value : ''
         };
         return _this;
     }
@@ -53,8 +54,17 @@ var Select = function (_React$Component) {
         value: function componentWillReceiveProps(nextProps) {
             if (nextProps.model && nextProps.form.key) {
                 this.setState({
-                    currentValue: nextProps.model[nextProps.form.key] || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
+                    currentValue: this.getModelKey(nextProps.model, nextProps.form.key) || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
                 });
+            }
+        }
+    }, {
+        key: 'getModelKey',
+        value: function getModelKey(model, key) {
+            if (Array.isArray(key)) {
+                return key.reduce((cur, nxt) => (cur[nxt]), model);
+            } else {
+                return model[key];
             }
         }
     }, {

--- a/lib/Select.js
+++ b/lib/Select.js
@@ -62,7 +62,9 @@ var Select = function (_React$Component) {
         key: 'getModelKey',
         value: function getModelKey(model, key) {
             if (Array.isArray(key)) {
-                return key.reduce((cur, nxt) => (cur[nxt]), model);
+                return key.reduce(function (cur, nxt) {
+                    return cur[nxt];
+                }, model);
             } else {
                 return model[key];
             }

--- a/src/Select.js
+++ b/src/Select.js
@@ -11,17 +11,26 @@ class Select extends React.Component {
     constructor(props) {
         super(props);
         this.onSelected = this.onSelected.bind(this);
+        var possibleValue = this.getModelKey(this.props.model, this.props.form.key);
         this.state = {
-            currentValue: this.props.model !== undefined ? this.props.model[this.props.form.key] : (this.props.form.titleMap != null ? this.props.form.titleMap[0].value : '')
+            currentValue: this.props.model !== undefined && possibleValue ? possibleValue : this.props.form.titleMap != null ? this.props.form.titleMap[0].value : ''
         };
     }
 
     componentWillReceiveProps(nextProps) {
         if (nextProps.model && nextProps.form.key) {
             this.setState({
-                currentValue: nextProps.model[nextProps.form.key]
+                currentValue: this.getModelKey(nextProps.model, nextProps.form.key)
                 || (nextProps.form.titleMap != null ? nextProps.form.titleMap[0].value : '')
             });
+        }
+    }
+
+    getModelKey(model, key) {
+        if (Array.isArray(key)) {
+            return key.reduce((cur, nxt) => (cur[nxt]), model);
+        } else {
+            return model[key];
         }
     }
 


### PR DESCRIPTION
If an array contains an enum then the key that gets passed down to Select.js is something like `["foo", 0, "bar"]` (or even crazier if there are more nested arrays/enums). This makes `props.model[props.form.key]` always return `undefined` in those cases due to the `key` being an array. The solution is to check if the key is an array and use each member of the array to drill down into the model until we get to the right key. (using a reduce)