### PR TITLE
Fix canonical title map utility

### DIFF
--- a/example/ExamplePage.js
+++ b/example/ExamplePage.js
@@ -92,10 +92,10 @@ var ExamplePage = React.createClass({
         }.bind(this));
     },
 
-    onModelChange: function(key, val) {
+    onModelChange: function(key, val, type) {
         console.log('ExamplePage.onModelChange:', key, val);
         var newModel = this.state.model;
-        utils.selectOrSet(key, newModel, val);
+        utils.selectOrSet(key, newModel, val, type);
         this.setState({ model: newModel });
     },
 

--- a/lib/ComposedComponent.js
+++ b/lib/ComposedComponent.js
@@ -63,7 +63,7 @@ var _default = function _default(ComposedComponent) {
         }, {
             key: 'onChangeValidate',
             value: function onChangeValidate(e) {
-                //console.log('onChangeValidate e', e);
+                // console.log('onChangeValidate e', e);
                 var value = null;
                 switch (this.props.form.schema.type) {
                     case 'integer':
@@ -97,7 +97,7 @@ var _default = function _default(ComposedComponent) {
                     error: validationResult.valid ? null : validationResult.error.message
                 });
                 //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-                this.props.onChange(this.props.form.key, value);
+                this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
             }
         }, {
             key: 'defaultValue',

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -85,7 +85,7 @@ var Date = function (_React$Component) {
                     value: value,
                     disabled: this.props.form.readonly,
                     style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
-                _react2.default.createElement(
+                this.props.value && _react2.default.createElement(
                     _IconButton2.default,
                     { ref: 'button',
                         onClick: function onClick() {

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -18,6 +18,14 @@ var _DatePicker = require('material-ui/DatePicker/DatePicker');
 
 var _DatePicker2 = _interopRequireDefault(_DatePicker);
 
+var _IconButton = require('material-ui/IconButton');
+
+var _IconButton2 = _interopRequireDefault(_IconButton);
+
+var _clear = require('material-ui/svg-icons/content/clear');
+
+var _clear2 = _interopRequireDefault(_clear);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56,6 +64,8 @@ var Date = function (_React$Component) {
     }, {
         key: 'render',
         value: function render() {
+            var _this2 = this;
+
             var value = null;
             if (this.props && this.props.value) {
                 value = this.props.value;
@@ -74,7 +84,16 @@ var Date = function (_React$Component) {
                     onDismiss: null,
                     value: value,
                     disabled: this.props.form.readonly,
-                    style: this.props.form.style || { width: '100%' } })
+                    style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
+                _react2.default.createElement(
+                    _IconButton2.default,
+                    { ref: 'button',
+                        onClick: function onClick() {
+                            return _this2.props.onChangeValidate("");
+                        },
+                        style: { position: 'relative', display: 'inline-block', top: '6px', right: '4px', padding: '0', width: '24px', height: '24px' } },
+                    _react2.default.createElement(_clear2.default, null)
+                )
             );
         }
     }]);

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -60,6 +60,11 @@ var Number = function (_React$Component) {
         value: function isNumeric(n) {
             return !isNaN(parseFloat(n)) && isFinite(n);
         }
+    }, {
+        key: 'isEmpty',
+        value: function isEmpty(n) {
+            return !n || 0 === n.length;
+        }
 
         /**
          * Prevent the field from accepting non-numeric characters.
@@ -74,6 +79,10 @@ var Number = function (_React$Component) {
                     lastSuccessfulValue: e.target.value
                 });
                 this.props.onChangeValidate(e);
+            } else if (this.isEmpty(e.target.value)) {
+                this.setState({
+                    lastSuccessfulValue: e.target.value
+                });
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -83,6 +83,7 @@ var Number = function (_React$Component) {
                 this.setState({
                     lastSuccessfulValue: e.target.value
                 });
+                this.props.onChangeValidate(e);
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -93,9 +93,9 @@ var SchemaForm = function (_React$Component) {
 
     _createClass(SchemaForm, [{
         key: 'onChange',
-        value: function onChange(key, val) {
+        value: function onChange(key, val, type) {
             //console.log('SchemaForm.onChange', key, val);
-            this.props.onModelChange(key, val);
+            this.props.onModelChange(key, val, type);
         }
     }, {
         key: 'builder',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,22 +34,14 @@ var enumToTitleMap = function enumToTitleMap(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function canonicalTitleMap(titleMap, originalEnum) {
-    if (!_lodash2.default.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function (value) {
-                canonical.push({ name: titleMap[value], value: value });
-            });
-        } else {
-            for (var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({ name: k, value: titleMap[k] });
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum) return titleMap;
+
+    var canonical = [];
+    var _enum = Object.keys(titleMap).length == 0 ? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -488,7 +488,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -507,6 +507,12 @@ function selectOrSet(projection, obj, valueToSet) {
     if (typeof valueToSet !== 'undefined' && typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' && ['number', 'integer'].indexOf(type) > -1 && typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -31,7 +31,7 @@ export default ComposedComponent => class extends React.Component {
      * @param e The input element, or something.
      */
     onChangeValidate(e) {
-        //console.log('onChangeValidate e', e);
+        // console.log('onChangeValidate e', e);
         let value = null;
         switch(this.props.form.schema.type) {
           case 'integer':
@@ -65,7 +65,7 @@ export default ComposedComponent => class extends React.Component {
             error: validationResult.valid ? null : validationResult.error.message
         });
         //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-        this.props.onChange(this.props.form.key, value);
+        this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
     }
 
     defaultValue(props) {

--- a/src/Date.js
+++ b/src/Date.js
@@ -44,11 +44,13 @@ class Date extends React.Component {
                     value={value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
-                <IconButton ref="button"
-                    onClick={() => this.props.onChangeValidate("")}
-                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
-                    <Clear />
-                </IconButton>
+                {this.props.value &&
+                    <IconButton ref="button"
+                        onClick={() => this.props.onChangeValidate("")}
+                        style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                        <Clear />
+                    </IconButton>
+                }
             </div>
         );
     }

--- a/src/Date.js
+++ b/src/Date.js
@@ -6,6 +6,8 @@ var utils = require('./utils');
 var classNames = require('classnames');
 import ComposedComponent from './ComposedComponent';
 import DatePicker from 'material-ui/DatePicker/DatePicker';
+import IconButton from 'material-ui/IconButton';
+import Clear from 'material-ui/svg-icons/content/clear';
 
 /**
  * There is no default number picker as part of Material-UI.
@@ -41,8 +43,12 @@ class Date extends React.Component {
                     onDismiss={null}
                     value={value}
                     disabled={this.props.form.readonly}
-                    style={this.props.form.style || {width: '100%'}}/>
-
+                    style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
+                <IconButton ref="button"
+                    onClick={() => this.props.onChangeValidate("")}
+                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                    <Clear />
+                </IconButton>
             </div>
         );
     }

--- a/src/Number.js
+++ b/src/Number.js
@@ -29,6 +29,10 @@ class Number extends React.Component {
         return !isNaN(parseFloat(n)) && isFinite(n);
     }
 
+    isEmpty(n) {
+        return (!n || 0 === n.length);
+    }
+
     /**
      * Prevent the field from accepting non-numeric characters.
      * @param e
@@ -39,8 +43,12 @@ class Number extends React.Component {
                 lastSuccessfulValue: e.target.value
             });
             this.props.onChangeValidate(e);
+        } else if (this.isEmpty(e.target.value)) {
+            this.setState({
+                lastSuccessfulValue: e.target.value
+            });
         } else {
-                this.refs.numberField.value = this.state.lastSuccessfulValue;
+            this.refs.numberField.value = this.state.lastSuccessfulValue;
         }
     }
 

--- a/src/Number.js
+++ b/src/Number.js
@@ -47,6 +47,7 @@ class Number extends React.Component {
             this.setState({
                 lastSuccessfulValue: e.target.value
             });
+            this.props.onChangeValidate(e);
         } else {
             this.refs.numberField.value = this.state.lastSuccessfulValue;
         }

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -36,9 +36,9 @@ class SchemaForm extends React.Component {
         this.onChange = this.onChange.bind(this);
     }
 
-    onChange(key, val) {
+    onChange(key, val, type) {
         //console.log('SchemaForm.onChange', key, val);
-        this.props.onModelChange(key, val);
+        this.props.onModelChange(key, val, type);
     }
 
     builder(form, model, index, onChange, mapper) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import _ from'lodash';
+import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
 
@@ -24,22 +24,15 @@ var enumToTitleMap = function(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function(titleMap, originalEnum) {
-    if (!_.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function(value) {
-                canonical.push({name: titleMap[value], value: value});
-            });
-        } else {
-            for(var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({name: k, value: titleMap[k]});
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum)
+        return titleMap;
+
+    const canonical = [];
+    const _enum = (Object.keys(titleMap).length == 0)? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/src/utils.js
+++ b/src/utils.js
@@ -462,7 +462,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -482,6 +482,14 @@ function selectOrSet(projection, obj, valueToSet) {
         typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' &&
+        ['number','integer'].indexOf(type) > -1 &&
+        typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];


### PR DESCRIPTION
# Canonical Title map simplification

It returns the canonical representation of the provided `titleMap` in a simple way, independently of if we're using a dict / key:value based mapping (`form.titleMap` object) or a sorted list map (`enumNames` array).

It also provides support for `enumNames` schema definition. Empty mappings are also handled.

Fix #86 enumNames are not resolved

### Tested scenarios

```
const schema = {
    "type": "object",
    "title": "An schema",
    "properties": {
        "owner": {
            "type": "object",
            "title": "A title",
            "required": [],
            "properties": {
                "language": {
                  "title": "Language with form titleMap",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ]
                },
                "language2": {
                  "title": "Language with enumNames",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ],
                  "enumNames": [
                    "cat",
                    "cast"
                  ]
                },
                "language3": {
                  "title": "Language without mapping",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ]
                }
            }
        },
        "required": []
    }
}


const form = [
    {
      "key": "owner.language",
      "titleMap": [
            {
                "value": "ca_ES",
                "name": "Català"
            },
            {
                "value": "es_ES",
                "name": "Castellano"
            }
        ]
    },
    "owner.language2",
    "owner.language3"
]

```

