### PR TITLE
Identify all SchemaForm fields by an unique key based on their form.key

### DIFF
--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -106,10 +106,13 @@ var SchemaForm = function (_React$Component) {
                 console.log('Invalid field: \"' + form.key[0] + '\"!');
                 return null;
             }
+            console.log(form.key, index);
             if (form.condition && eval(form.condition) === false) {
                 return null;
             }
-            return _react2.default.createElement(Field, { model: model, form: form, key: index, onChange: onChange, mapper: mapper, builder: this.builder });
+
+            var key = form.key && form.key.join(".") || index;
+            return _react2.default.createElement(Field, { model: model, form: form, key: key, onChange: onChange, mapper: mapper, builder: this.builder });
         }
     }, {
         key: 'render',

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -48,10 +48,13 @@ class SchemaForm extends React.Component {
           console.log('Invalid field: \"' + form.key[0] + '\"!');
           return null;
         }
+
         if(form.condition && eval(form.condition) === false) {
           return null;
         }
-        return <Field model={model} form={form} key={index} onChange={onChange} mapper={mapper} builder={this.builder}/>
+
+        const key = form.key && form.key.join(".") || index;
+        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder}/>
     }
 
     render() {


### PR DESCRIPTION
It uses the `form.key` to provide an unique string identifier for each `SchemaForm` field.

If the `form.key` is not provided, it uses the ordinal index instead.

It also introduces a quick way to reference all form fields based on their schema key.

Fix #88