### PR TITLE
Autocomplete field

### DIFF
--- a/example/ExamplePage.js
+++ b/example/ExamplePage.js
@@ -92,10 +92,10 @@ var ExamplePage = React.createClass({
         }.bind(this));
     },
 
-    onModelChange: function(key, val) {
+    onModelChange: function(key, val, type) {
         console.log('ExamplePage.onModelChange:', key, val);
         var newModel = this.state.model;
-        utils.selectOrSet(key, newModel, val);
+        utils.selectOrSet(key, newModel, val, type);
         this.setState({ model: newModel });
     },
 

--- a/lib/ComposedComponent.js
+++ b/lib/ComposedComponent.js
@@ -63,7 +63,7 @@ var _default = function _default(ComposedComponent) {
         }, {
             key: 'onChangeValidate',
             value: function onChangeValidate(e) {
-                //console.log('onChangeValidate e', e);
+                // console.log('onChangeValidate e', e);
                 var value = null;
                 switch (this.props.form.schema.type) {
                     case 'integer':
@@ -97,7 +97,7 @@ var _default = function _default(ComposedComponent) {
                     error: validationResult.valid ? null : validationResult.error.message
                 });
                 //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-                this.props.onChange(this.props.form.key, value);
+                this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
             }
         }, {
             key: 'defaultValue',

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -85,7 +85,7 @@ var Date = function (_React$Component) {
                     value: value,
                     disabled: this.props.form.readonly,
                     style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
-                _react2.default.createElement(
+                this.props.value && _react2.default.createElement(
                     _IconButton2.default,
                     { ref: 'button',
                         onClick: function onClick() {

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -18,6 +18,14 @@ var _DatePicker = require('material-ui/DatePicker/DatePicker');
 
 var _DatePicker2 = _interopRequireDefault(_DatePicker);
 
+var _IconButton = require('material-ui/IconButton');
+
+var _IconButton2 = _interopRequireDefault(_IconButton);
+
+var _clear = require('material-ui/svg-icons/content/clear');
+
+var _clear2 = _interopRequireDefault(_clear);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56,6 +64,8 @@ var Date = function (_React$Component) {
     }, {
         key: 'render',
         value: function render() {
+            var _this2 = this;
+
             var value = null;
             if (this.props && this.props.value) {
                 value = this.props.value;
@@ -74,7 +84,16 @@ var Date = function (_React$Component) {
                     onDismiss: null,
                     value: value,
                     disabled: this.props.form.readonly,
-                    style: this.props.form.style || { width: '100%' } })
+                    style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
+                _react2.default.createElement(
+                    _IconButton2.default,
+                    { ref: 'button',
+                        onClick: function onClick() {
+                            return _this2.props.onChangeValidate("");
+                        },
+                        style: { position: 'relative', display: 'inline-block', top: '6px', right: '4px', padding: '0', width: '24px', height: '24px' } },
+                    _react2.default.createElement(_clear2.default, null)
+                )
             );
         }
     }]);

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -60,6 +60,11 @@ var Number = function (_React$Component) {
         value: function isNumeric(n) {
             return !isNaN(parseFloat(n)) && isFinite(n);
         }
+    }, {
+        key: 'isEmpty',
+        value: function isEmpty(n) {
+            return !n || 0 === n.length;
+        }
 
         /**
          * Prevent the field from accepting non-numeric characters.
@@ -74,6 +79,10 @@ var Number = function (_React$Component) {
                     lastSuccessfulValue: e.target.value
                 });
                 this.props.onChangeValidate(e);
+            } else if (this.isEmpty(e.target.value)) {
+                this.setState({
+                    lastSuccessfulValue: e.target.value
+                });
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -83,6 +83,7 @@ var Number = function (_React$Component) {
                 this.setState({
                     lastSuccessfulValue: e.target.value
                 });
+                this.props.onChangeValidate(e);
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -111,10 +111,13 @@ var SchemaForm = function (_React$Component) {
                 console.log('Invalid field: \"' + form.key[0] + '\"!');
                 return null;
             }
-            if (form.condition && eval(form.condition) === false) {
+
+            if (form.condition && _utils2.default.safeEval(form.condition, { model: model }) === false) {
                 return null;
             }
-            return _react2.default.createElement(Field, { model: model, form: form, key: index, onChange: onChange, mapper: mapper, builder: this.builder });
+
+            var key = form.key && form.key.join(".") || index;
+            return _react2.default.createElement(Field, { model: model, form: form, key: key, onChange: onChange, mapper: mapper, builder: this.builder });
         }
     }, {
         key: 'render',

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -22,6 +22,10 @@ var _TextArea = require('./TextArea');
 
 var _TextArea2 = _interopRequireDefault(_TextArea);
 
+var _TextSuggest = require('./TextSuggest');
+
+var _TextSuggest2 = _interopRequireDefault(_TextSuggest);
+
 var _Select = require('./Select');
 
 var _Select2 = _interopRequireDefault(_Select);
@@ -78,6 +82,7 @@ var SchemaForm = function (_React$Component) {
             'text': _Text2.default,
             'password': _Text2.default,
             'textarea': _TextArea2.default,
+            'textsuggest': _TextSuggest2.default,
             'select': _Select2.default,
             'radios': _Radios2.default,
             'date': _Date2.default,

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -93,9 +93,9 @@ var SchemaForm = function (_React$Component) {
 
     _createClass(SchemaForm, [{
         key: 'onChange',
-        value: function onChange(key, val) {
+        value: function onChange(key, val, type) {
             //console.log('SchemaForm.onChange', key, val);
-            this.props.onModelChange(key, val);
+            this.props.onModelChange(key, val, type);
         }
     }, {
         key: 'builder',

--- a/lib/TextSuggest.js
+++ b/lib/TextSuggest.js
@@ -1,0 +1,157 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _ComposedComponent = require('./ComposedComponent');
+
+var _ComposedComponent2 = _interopRequireDefault(_ComposedComponent);
+
+var _AutoComplete = require('material-ui/AutoComplete');
+
+var _AutoComplete2 = _interopRequireDefault(_AutoComplete);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * Created by XaviTorello on 30/05/18
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
+
+
+var dataSourceConfig = {
+    text: 'name',
+    value: 'value'
+};
+
+var TextSuggest = function (_React$Component) {
+    _inherits(TextSuggest, _React$Component);
+
+    function TextSuggest() {
+        var _ref;
+
+        var _temp, _this, _ret;
+
+        _classCallCheck(this, TextSuggest);
+
+        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+            args[_key] = arguments[_key];
+        }
+
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TextSuggest.__proto__ || Object.getPrototypeOf(TextSuggest)).call.apply(_ref, [this].concat(args))), _this), _this.handleUpdate = function () {
+            var _this2;
+
+            return (_this2 = _this).__handleUpdate__REACT_HOT_LOADER__.apply(_this2, arguments);
+        }, _this.handleInit = function () {
+            var _this3;
+
+            return (_this3 = _this).__handleInit__REACT_HOT_LOADER__.apply(_this3, arguments);
+        }, _temp), _possibleConstructorReturn(_this, _ret);
+    }
+
+    _createClass(TextSuggest, [{
+        key: '__handleInit__REACT_HOT_LOADER__',
+        value: function __handleInit__REACT_HOT_LOADER__() {
+            return this.__handleInit__REACT_HOT_LOADER__.apply(this, arguments);
+        }
+    }, {
+        key: '__handleUpdate__REACT_HOT_LOADER__',
+        value: function __handleUpdate__REACT_HOT_LOADER__() {
+            return this.__handleUpdate__REACT_HOT_LOADER__.apply(this, arguments);
+        }
+    }, {
+        key: '__handleUpdate__REACT_HOT_LOADER__',
+        value: function __handleUpdate__REACT_HOT_LOADER__(newValue, index) {
+            var key = this.props.form.key;
+            var type = this.props.form.schema.type;
+
+            return this.props.onChange(key, newValue[dataSourceConfig['value']], type);
+        }
+    }, {
+        key: '__handleInit__REACT_HOT_LOADER__',
+        value: function __handleInit__REACT_HOT_LOADER__(init_value) {
+            if (!this.props.form.schema || !this.props.form.schema.enum) return init_value.toString();
+
+            var names = this.props.form.schema.enumNames || this.props.form.schema.enum;
+            var values = this.props.form.schema.enum;
+
+            console.log(names, values);
+            console.log("indexOf", values.indexOf(init_value));
+            console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+            var init_value_name = names[values.indexOf(init_value)];
+
+            // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
+
+            return init_value_name || init_value.toString();
+        }
+    }, {
+        key: 'render',
+        value: function render() {
+            // console.log('TextSuggest', this.props);
+            // assign the filter, by default case insensitive
+            var filter = function (filter) {
+                switch (filter) {
+                    case 'fuzzy':
+                        return _AutoComplete2.default.fuzzyFilter;
+                        break;
+                    default:
+                        return _AutoComplete2.default.caseInsensitiveFilter;
+                        break;
+                }
+            }(this.props.form.filter);
+
+            var value = this.props.value && this.handleInit(this.props.value);
+
+            return _react2.default.createElement(
+                'div',
+                { className: this.props.form.htmlClass },
+                _react2.default.createElement(_AutoComplete2.default, {
+                    type: this.props.form.type,
+                    floatingLabelText: this.props.form.title,
+                    hintText: this.props.form.placeholder,
+                    errorText: this.props.error,
+                    onNewRequest: this.handleUpdate,
+                    disabled: this.props.form.readonly,
+                    style: this.props.form.style || { width: '100%' },
+                    openOnFocus: true,
+                    searchText: value,
+                    dataSource: this.props.form.titleMap || ['Loading...'],
+                    filter: filter,
+                    maxSearchResults: this.props.form.maxSearchResults || 5,
+                    dataSourceConfig: dataSourceConfig
+                })
+            );
+        }
+    }]);
+
+    return TextSuggest;
+}(_react2.default.Component);
+
+var _default = (0, _ComposedComponent2.default)(TextSuggest);
+
+exports.default = _default;
+;
+
+var _temp2 = function () {
+    if (typeof __REACT_HOT_LOADER__ === 'undefined') {
+        return;
+    }
+
+    __REACT_HOT_LOADER__.register(dataSourceConfig, 'dataSourceConfig', 'src/TextSuggest.js');
+
+    __REACT_HOT_LOADER__.register(TextSuggest, 'TextSuggest', 'src/TextSuggest.js');
+
+    __REACT_HOT_LOADER__.register(_default, 'default', 'src/TextSuggest.js');
+}();
+
+;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,22 +34,14 @@ var enumToTitleMap = function enumToTitleMap(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function canonicalTitleMap(titleMap, originalEnum) {
-    if (!_lodash2.default.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function (value) {
-                canonical.push({ name: titleMap[value], value: value });
-            });
-        } else {
-            for (var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({ name: k, value: titleMap[k] });
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum) return titleMap;
+
+    var canonical = [];
+    var _enum = Object.keys(titleMap).length == 0 ? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -488,7 +488,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -507,6 +507,12 @@ function selectOrSet(projection, obj, valueToSet) {
     if (typeof valueToSet !== 'undefined' && typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' && ['number', 'integer'].indexOf(type) > -1 && typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,21 @@ var _tv = require('tv4');
 
 var _tv2 = _interopRequireDefault(_tv);
 
+var _notevil = require('notevil');
+
+var _notevil2 = _interopRequireDefault(_notevil);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    try {
+        var scope_safe = _lodash2.default.cloneDeep(scope);
+        return (0, _notevil2.default)(condition, scope_safe);
+    } catch (error) {
+        return undefined;
+    }
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -619,6 +633,7 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };
 ;
@@ -627,6 +642,8 @@ var _temp = function () {
     if (typeof __REACT_HOT_LOADER__ === 'undefined') {
         return;
     }
+
+    __REACT_HOT_LOADER__.register(safeEval, 'safeEval', 'src/utils.js');
 
     __REACT_HOT_LOADER__.register(stripNullType, 'stripNullType', 'src/utils.js');
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lodash": "^4.16.6",
     "objectpath": "^1.2.1",
     "react-autosuggest": "^9.3.4",
+    "notevil": "^1.1.0",
     "tv4": "^1.2.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.6",
     "objectpath": "^1.2.1",
+    "react-autosuggest": "^9.3.4",
     "tv4": "^1.2.7"
   },
   "devDependencies": {

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -31,7 +31,7 @@ export default ComposedComponent => class extends React.Component {
      * @param e The input element, or something.
      */
     onChangeValidate(e) {
-        //console.log('onChangeValidate e', e);
+        // console.log('onChangeValidate e', e);
         let value = null;
         switch(this.props.form.schema.type) {
           case 'integer':
@@ -65,7 +65,7 @@ export default ComposedComponent => class extends React.Component {
             error: validationResult.valid ? null : validationResult.error.message
         });
         //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-        this.props.onChange(this.props.form.key, value);
+        this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
     }
 
     defaultValue(props) {

--- a/src/Date.js
+++ b/src/Date.js
@@ -44,11 +44,13 @@ class Date extends React.Component {
                     value={value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
-                <IconButton ref="button"
-                    onClick={() => this.props.onChangeValidate("")}
-                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
-                    <Clear />
-                </IconButton>
+                {this.props.value &&
+                    <IconButton ref="button"
+                        onClick={() => this.props.onChangeValidate("")}
+                        style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                        <Clear />
+                    </IconButton>
+                }
             </div>
         );
     }

--- a/src/Date.js
+++ b/src/Date.js
@@ -6,6 +6,8 @@ var utils = require('./utils');
 var classNames = require('classnames');
 import ComposedComponent from './ComposedComponent';
 import DatePicker from 'material-ui/DatePicker/DatePicker';
+import IconButton from 'material-ui/IconButton';
+import Clear from 'material-ui/svg-icons/content/clear';
 
 /**
  * There is no default number picker as part of Material-UI.
@@ -41,8 +43,12 @@ class Date extends React.Component {
                     onDismiss={null}
                     value={value}
                     disabled={this.props.form.readonly}
-                    style={this.props.form.style || {width: '100%'}}/>
-
+                    style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
+                <IconButton ref="button"
+                    onClick={() => this.props.onChangeValidate("")}
+                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                    <Clear />
+                </IconButton>
             </div>
         );
     }

--- a/src/Number.js
+++ b/src/Number.js
@@ -29,6 +29,10 @@ class Number extends React.Component {
         return !isNaN(parseFloat(n)) && isFinite(n);
     }
 
+    isEmpty(n) {
+        return (!n || 0 === n.length);
+    }
+
     /**
      * Prevent the field from accepting non-numeric characters.
      * @param e
@@ -39,8 +43,12 @@ class Number extends React.Component {
                 lastSuccessfulValue: e.target.value
             });
             this.props.onChangeValidate(e);
+        } else if (this.isEmpty(e.target.value)) {
+            this.setState({
+                lastSuccessfulValue: e.target.value
+            });
         } else {
-                this.refs.numberField.value = this.state.lastSuccessfulValue;
+            this.refs.numberField.value = this.state.lastSuccessfulValue;
         }
     }
 

--- a/src/Number.js
+++ b/src/Number.js
@@ -47,6 +47,7 @@ class Number extends React.Component {
             this.setState({
                 lastSuccessfulValue: e.target.value
             });
+            this.props.onChangeValidate(e);
         } else {
             this.refs.numberField.value = this.state.lastSuccessfulValue;
         }

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -6,6 +6,7 @@ import utils from './utils';
 import Number from './Number';
 import Text from './Text';
 import TextArea from './TextArea';
+import TextSuggest from './TextSuggest';
 import Select from './Select';
 import Radios from './Radios';
 import Date from './Date';
@@ -22,6 +23,7 @@ class SchemaForm extends React.Component {
         'text': Text,
         'password': Text,
         'textarea': TextArea,
+        'textsuggest': TextSuggest,
         'select': Select,
         'radios': Radios,
         'date': Date,

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -36,9 +36,9 @@ class SchemaForm extends React.Component {
         this.onChange = this.onChange.bind(this);
     }
 
-    onChange(key, val) {
+    onChange(key, val, type) {
         //console.log('SchemaForm.onChange', key, val);
-        this.props.onModelChange(key, val);
+        this.props.onModelChange(key, val, type);
     }
 
     builder(form, model, index, onChange, mapper) {

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -50,10 +50,13 @@ class SchemaForm extends React.Component {
           console.log('Invalid field: \"' + form.key[0] + '\"!');
           return null;
         }
-        if(form.condition && eval(form.condition) === false) {
+
+        if(form.condition && utils.safeEval(form.condition, {model}) === false) {
           return null;
         }
-        return <Field model={model} form={form} key={index} onChange={onChange} mapper={mapper} builder={this.builder}/>
+
+        const key = form.key && form.key.join(".") || index;
+        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder}/>
     }
 
     render() {

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -14,8 +14,25 @@ class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
       const {key} = this.props.form
       const {type} = this.props.form.schema
-      this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+      return this.props.onChange(key, newValue[dataSourceConfig['value']], type)
     };
+
+    handleInit = (init_value) => {
+        if (!this.props.form.schema || !this.props.form.schema.enum)
+            return init_value.toString()
+
+        const names = this.props.form.schema.enumNames || this.props.form.schema.enum;
+        const values = this.props.form.schema.enum;
+
+        console.log(names, values);
+        console.log("indexOf", values.indexOf(init_value));
+        console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+        const init_value_name = names[values.indexOf(init_value)];
+
+        // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
+
+        return init_value_name || init_value.toString()
+    }
 
     render() {
         // console.log('TextSuggest', this.props);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -14,7 +14,7 @@ class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
       const {key} = this.props.form
       const {type} = this.props.form.schema
-      return this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+      return this.props.onChange(key, newValue[dataSourceConfig['value']], type, this.props.form)
     };
 
     handleInit = (init_value) => {
@@ -24,9 +24,9 @@ class TextSuggest extends React.Component {
         const names = this.props.form.schema.enumNames || this.props.form.schema.enum;
         const values = this.props.form.schema.enum;
 
-        console.log(names, values);
-        console.log("indexOf", values.indexOf(init_value));
-        console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+        // console.log(names, values);
+        // console.log("indexOf", values.indexOf(init_value));
+        // console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
         const init_value_name = names[values.indexOf(init_value)];
 
         // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
@@ -47,6 +47,8 @@ class TextSuggest extends React.Component {
                     break;
             }
         })(this.props.form.filter)
+
+        // console.log("TEXTSUG", this.props);
 
         const value = this.props.value && this.handleInit(this.props.value);
 

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -40,10 +40,11 @@ class TextSuggest extends React.Component {
                     defaultValue={this.props.value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
-                    dataSource={datasource}
                     openOnFocus={true}
+                    dataSource={this.props.form.titleMap || ['Loading...']}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}
+                    dataSourceConfig={dataSourceConfig}
                 />
             </div>
         );

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -12,7 +12,6 @@ const dataSourceConfig = {
 
 class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
-      console.log("changing", newValue, index);
       const {key} = this.props.form
       const {type} = this.props.form.schema
       this.props.onChange(key, newValue[dataSourceConfig['value']], type)

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -48,6 +48,8 @@ class TextSuggest extends React.Component {
             }
         })(this.props.form.filter)
 
+        const value = this.props.value && this.handleInit(this.props.value);
+
         return (
             <div className={this.props.form.htmlClass}>
                 <AutoComplete
@@ -59,6 +61,7 @@ class TextSuggest extends React.Component {
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     openOnFocus={true}
+                    searchText={value}
                     dataSource={this.props.form.titleMap || ['Loading...']}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -5,6 +5,11 @@ import React from 'react';
 import ComposedComponent from './ComposedComponent';
 import AutoComplete from 'material-ui/AutoComplete';
 
+const dataSourceConfig = {
+  text: 'name',
+  value: 'value',
+};
+
 class TextSuggest extends React.Component {
     render() {
         // console.log('TextSuggest', this.props.form);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -41,6 +41,7 @@ class TextSuggest extends React.Component {
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     dataSource={datasource}
+                    openOnFocus={true}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}
                 />

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -1,0 +1,29 @@
+/**
+ * Created by XaviTorello on 30/05/18
+ */
+import React from 'react';
+import ComposedComponent from './ComposedComponent';
+import TextField from 'material-ui/TextField';
+
+class TextSuggest extends React.Component {
+    render() {
+        console.log('TextSuggest', this.props.form);
+        return (
+            <div className={this.props.form.htmlClass}>
+                <TextField
+                    type={this.props.form.type}
+                    floatingLabelText={this.props.form.title}
+                    hintText={this.props.form.placeholder}
+                    errorText={this.props.error}
+                    onChange={this.props.onChangeValidate}
+                    defaultValue={this.props.value}
+                    disabled={this.props.form.readonly}
+                    autoComplete={this.props.form.autoComplete}
+                    style={this.props.form.style || {width: '100%'}}
+                />
+            </div>
+        );
+    }
+}
+
+export default ComposedComponent(TextSuggest);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -3,14 +3,30 @@
  */
 import React from 'react';
 import ComposedComponent from './ComposedComponent';
-import TextField from 'material-ui/TextField';
+import AutoComplete from 'material-ui/AutoComplete';
 
 class TextSuggest extends React.Component {
     render() {
-        console.log('TextSuggest', this.props.form);
+        // console.log('TextSuggest', this.props.form);
+
+        // assign the source list to autocomplete
+        const datasource = this.props.form.schema.enumNames || this.props.form.schema.enum || ['Loading...'];
+
+        // assign the filter, by default case insensitive
+        const filter = ((filter) => {
+            switch (filter) {
+                case 'fuzzy':
+                    return AutoComplete.fuzzyFilter;
+                    break;
+                default:
+                    return AutoComplete.caseInsensitiveFilter;
+                    break;
+            }
+        })(this.props.form.filter)
+
         return (
             <div className={this.props.form.htmlClass}>
-                <TextField
+                <AutoComplete
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
@@ -18,8 +34,10 @@ class TextSuggest extends React.Component {
                     onChange={this.props.onChangeValidate}
                     defaultValue={this.props.value}
                     disabled={this.props.form.readonly}
-                    autoComplete={this.props.form.autoComplete}
                     style={this.props.form.style || {width: '100%'}}
+                    dataSource={datasource}
+                    filter={filter}
+                    maxSearchResults={this.props.form.maxSearchResults || 5}
                 />
             </div>
         );

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -11,12 +11,15 @@ const dataSourceConfig = {
 };
 
 class TextSuggest extends React.Component {
+    handleUpdate = (newValue, index) => {
+      console.log("changing", newValue, index);
+      const {key} = this.props.form
+      const {type} = this.props.form.schema
+      this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+    };
+
     render() {
-        // console.log('TextSuggest', this.props.form);
-
-        // assign the source list to autocomplete
-        const datasource = this.props.form.schema.enumNames || this.props.form.schema.enum || ['Loading...'];
-
+        // console.log('TextSuggest', this.props);
         // assign the filter, by default case insensitive
         const filter = ((filter) => {
             switch (filter) {
@@ -36,8 +39,7 @@ class TextSuggest extends React.Component {
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
                     errorText={this.props.error}
-                    onChange={this.props.onChangeValidate}
-                    defaultValue={this.props.value}
+                    onNewRequest={this.handleUpdate}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     openOnFocus={true}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import _ from'lodash';
+import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
 
@@ -24,22 +24,15 @@ var enumToTitleMap = function(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function(titleMap, originalEnum) {
-    if (!_.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function(value) {
-                canonical.push({name: titleMap[value], value: value});
-            });
-        } else {
-            for(var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({name: k, value: titleMap[k]});
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum)
+        return titleMap;
+
+    const canonical = [];
+    const _enum = (Object.keys(titleMap).length == 0)? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/src/utils.js
+++ b/src/utils.js
@@ -402,9 +402,9 @@ function merge(schema, form, ignore, options, readonly) {
             }
         }
 
-        //If it has a titleMap make sure it's a list
+        //If it has a titleMap make sure to update it with latest enum and names
         if (obj.titleMap) {
-            obj.titleMap = canonicalTitleMap(obj.titleMap);
+            obj.titleMap = canonicalTitleMap(obj.schema.enumNames, obj.schema.enum);
         }
 
         //

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,17 @@
 import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
+import notevil from 'notevil';
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    try {
+        const scope_safe = _.cloneDeep(scope);
+        return notevil(condition, scope_safe);
+    } catch (error) {
+        return undefined
+    }
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -600,5 +611,6 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -462,7 +462,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -482,6 +482,14 @@ function selectOrSet(projection, obj, valueToSet) {
         typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' &&
+        ['number','integer'].indexOf(type) > -1 &&
+        typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];


### PR DESCRIPTION
# TextSuggest component

It provides the `<TextSuggest>` component devised to render a list of elements using a material-ui `Autocomplete`.

![textsuggest](https://user-images.githubusercontent.com/8709244/41395895-8f9463a6-6faf-11e8-91e9-6758d35aea23.png)

The behaviour of this component is very similar to the `<Select>`, it deals with a list of elements and their possible names:

```
schema = {
    ...
    "state": 
        "enum": [
            "first_code",
            "second_code"
        ],
        "enumNames": [
            "first_label",
            "second_label"
        ],
        "title": "This is a title", 
        "type": "string",
        "default": "second_code",
    ],
    ...
}

form = {
    ...
    {
        "key": "state",  
        "type": "textsuggest"
    },
    ...
}
```

Fix #94 Autocomplete component