### PR TITLE
External errors management

### DIFF
--- a/example/ExamplePage.js
+++ b/example/ExamplePage.js
@@ -92,10 +92,10 @@ var ExamplePage = React.createClass({
         }.bind(this));
     },
 
-    onModelChange: function(key, val) {
+    onModelChange: function(key, val, type) {
         console.log('ExamplePage.onModelChange:', key, val);
         var newModel = this.state.model;
-        utils.selectOrSet(key, newModel, val);
+        utils.selectOrSet(key, newModel, val, type);
         this.setState({ model: newModel });
     },
 

--- a/lib/ComposedComponent.js
+++ b/lib/ComposedComponent.js
@@ -63,7 +63,7 @@ var _default = function _default(ComposedComponent) {
         }, {
             key: 'onChangeValidate',
             value: function onChangeValidate(e) {
-                //console.log('onChangeValidate e', e);
+                // console.log('onChangeValidate e', e);
                 var value = null;
                 switch (this.props.form.schema.type) {
                     case 'integer':
@@ -97,7 +97,7 @@ var _default = function _default(ComposedComponent) {
                     error: validationResult.valid ? null : validationResult.error.message
                 });
                 //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-                this.props.onChange(this.props.form.key, value);
+                this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
             }
         }, {
             key: 'defaultValue',

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -85,7 +85,7 @@ var Date = function (_React$Component) {
                     value: value,
                     disabled: this.props.form.readonly,
                     style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
-                _react2.default.createElement(
+                this.props.value && _react2.default.createElement(
                     _IconButton2.default,
                     { ref: 'button',
                         onClick: function onClick() {

--- a/lib/Date.js
+++ b/lib/Date.js
@@ -18,6 +18,14 @@ var _DatePicker = require('material-ui/DatePicker/DatePicker');
 
 var _DatePicker2 = _interopRequireDefault(_DatePicker);
 
+var _IconButton = require('material-ui/IconButton');
+
+var _IconButton2 = _interopRequireDefault(_IconButton);
+
+var _clear = require('material-ui/svg-icons/content/clear');
+
+var _clear2 = _interopRequireDefault(_clear);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -56,6 +64,8 @@ var Date = function (_React$Component) {
     }, {
         key: 'render',
         value: function render() {
+            var _this2 = this;
+
             var value = null;
             if (this.props && this.props.value) {
                 value = this.props.value;
@@ -74,7 +84,16 @@ var Date = function (_React$Component) {
                     onDismiss: null,
                     value: value,
                     disabled: this.props.form.readonly,
-                    style: this.props.form.style || { width: '100%' } })
+                    style: this.props.form.style || { width: '90%', display: 'inline-block' } }),
+                _react2.default.createElement(
+                    _IconButton2.default,
+                    { ref: 'button',
+                        onClick: function onClick() {
+                            return _this2.props.onChangeValidate("");
+                        },
+                        style: { position: 'relative', display: 'inline-block', top: '6px', right: '4px', padding: '0', width: '24px', height: '24px' } },
+                    _react2.default.createElement(_clear2.default, null)
+                )
             );
         }
     }]);

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -60,6 +60,11 @@ var Number = function (_React$Component) {
         value: function isNumeric(n) {
             return !isNaN(parseFloat(n)) && isFinite(n);
         }
+    }, {
+        key: 'isEmpty',
+        value: function isEmpty(n) {
+            return !n || 0 === n.length;
+        }
 
         /**
          * Prevent the field from accepting non-numeric characters.
@@ -74,6 +79,10 @@ var Number = function (_React$Component) {
                     lastSuccessfulValue: e.target.value
                 });
                 this.props.onChangeValidate(e);
+            } else if (this.isEmpty(e.target.value)) {
+                this.setState({
+                    lastSuccessfulValue: e.target.value
+                });
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/Number.js
+++ b/lib/Number.js
@@ -83,6 +83,7 @@ var Number = function (_React$Component) {
                 this.setState({
                     lastSuccessfulValue: e.target.value
                 });
+                this.props.onChangeValidate(e);
             } else {
                 this.refs.numberField.value = this.state.lastSuccessfulValue;
             }

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -106,10 +106,13 @@ var SchemaForm = function (_React$Component) {
                 console.log('Invalid field: \"' + form.key[0] + '\"!');
                 return null;
             }
+            console.log(form.key, index);
             if (form.condition && eval(form.condition) === false) {
                 return null;
             }
-            return _react2.default.createElement(Field, { model: model, form: form, key: index, onChange: onChange, mapper: mapper, builder: this.builder });
+
+            var key = form.key && form.key.join(".") || index;
+            return _react2.default.createElement(Field, { model: model, form: form, key: key, onChange: onChange, mapper: mapper, builder: this.builder });
         }
     }, {
         key: 'render',

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -93,9 +93,9 @@ var SchemaForm = function (_React$Component) {
 
     _createClass(SchemaForm, [{
         key: 'onChange',
-        value: function onChange(key, val) {
+        value: function onChange(key, val, type) {
             //console.log('SchemaForm.onChange', key, val);
-            this.props.onModelChange(key, val);
+            this.props.onModelChange(key, val, type);
         }
     }, {
         key: 'builder',

--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -106,8 +106,8 @@ var SchemaForm = function (_React$Component) {
                 console.log('Invalid field: \"' + form.key[0] + '\"!');
                 return null;
             }
-            console.log(form.key, index);
-            if (form.condition && eval(form.condition) === false) {
+
+            if (form.condition && _utils2.default.safeEval(form.condition, { model: model }) === false) {
                 return null;
             }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,22 +34,14 @@ var enumToTitleMap = function enumToTitleMap(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function canonicalTitleMap(titleMap, originalEnum) {
-    if (!_lodash2.default.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function (value) {
-                canonical.push({ name: titleMap[value], value: value });
-            });
-        } else {
-            for (var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({ name: k, value: titleMap[k] });
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum) return titleMap;
+
+    var canonical = [];
+    var _enum = Object.keys(titleMap).length == 0 ? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -488,7 +488,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -507,6 +507,12 @@ function selectOrSet(projection, obj, valueToSet) {
     if (typeof valueToSet !== 'undefined' && typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' && ['number', 'integer'].indexOf(type) > -1 && typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,21 @@ var _tv = require('tv4');
 
 var _tv2 = _interopRequireDefault(_tv);
 
+var _notevil = require('notevil');
+
+var _notevil2 = _interopRequireDefault(_notevil);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    try {
+        var scope_safe = _lodash2.default.cloneDeep(scope);
+        return (0, _notevil2.default)(condition, scope_safe);
+    } catch (error) {
+        return undefined;
+    }
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -619,6 +633,7 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };
 ;
@@ -627,6 +642,8 @@ var _temp = function () {
     if (typeof __REACT_HOT_LOADER__ === 'undefined') {
         return;
     }
+
+    __REACT_HOT_LOADER__.register(safeEval, 'safeEval', 'src/utils.js');
 
     __REACT_HOT_LOADER__.register(stripNullType, 'stripNullType', 'src/utils.js');
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.6",
     "objectpath": "^1.2.1",
-    "tv4": "^1.2.7"
+    "tv4": "^1.2.7",
+    "notevil": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -11,12 +11,17 @@ const styles = {
         fontSize: "12px",
         lineHeight: "12px",
     },
+    checkbox: {
+        marginTop: "14px",
+        marginBottom: "0px",
+        height: "72px",
+    },
 };
 
 class Checkbox2 extends React.Component {
     render() {
         return (
-            <div className={this.props.form.className}>
+            <div className={this.props.form.className} style={styles.checkbox}>
                 <Checkbox
                     name={this.props.form.key.slice(-1)[0]}
                     value={this.props.form.key.slice(-1)[0]}

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -5,6 +5,14 @@ import React from 'react';
 import ComposedComponent from './ComposedComponent';
 import Checkbox from 'material-ui/Checkbox';
 
+const styles = {
+    error: {
+        color: "rgb(244, 67, 54)",
+        fontSize: "12px",
+        lineHeight: "12px",
+    },
+};
+
 class Checkbox2 extends React.Component {
     render() {
         return (
@@ -17,6 +25,7 @@ class Checkbox2 extends React.Component {
                     disabled={this.props.form.readonly}
                     onCheck={(e, checked) => {this.props.onChangeValidate(e)}}
                     />
+                <span style={styles.error}>{this.props.errorText}</span>
              </div>
         );
     }

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -12,7 +12,7 @@ export default ComposedComponent => class extends React.Component {
         this.state = {
             value: value,
             valid: !!(validationResult.valid || !value),
-            error: !validationResult.valid && value ? validationResult.error.message : null
+            error: !validationResult.valid && (value ? validationResult.error.message : null) || this.props.errorText
         };
     }
 

--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -31,7 +31,7 @@ export default ComposedComponent => class extends React.Component {
      * @param e The input element, or something.
      */
     onChangeValidate(e) {
-        //console.log('onChangeValidate e', e);
+        // console.log('onChangeValidate e', e);
         let value = null;
         switch(this.props.form.schema.type) {
           case 'integer':
@@ -65,7 +65,7 @@ export default ComposedComponent => class extends React.Component {
             error: validationResult.valid ? null : validationResult.error.message
         });
         //console.log('conhangeValidate this.props.form.key, value', this.props.form.key, value);
-        this.props.onChange(this.props.form.key, value);
+        this.props.onChange(this.props.form.key, value, this.props.form.schema.type);
     }
 
     defaultValue(props) {

--- a/src/Date.js
+++ b/src/Date.js
@@ -44,11 +44,13 @@ class Date extends React.Component {
                     value={value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
-                <IconButton ref="button"
-                    onClick={() => this.props.onChangeValidate("")}
-                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
-                    <Clear />
-                </IconButton>
+                {this.props.value &&
+                    <IconButton ref="button"
+                        onClick={() => this.props.onChangeValidate("")}
+                        style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                        <Clear />
+                    </IconButton>
+                }
             </div>
         );
     }

--- a/src/Date.js
+++ b/src/Date.js
@@ -6,6 +6,8 @@ var utils = require('./utils');
 var classNames = require('classnames');
 import ComposedComponent from './ComposedComponent';
 import DatePicker from 'material-ui/DatePicker/DatePicker';
+import IconButton from 'material-ui/IconButton';
+import Clear from 'material-ui/svg-icons/content/clear';
 
 /**
  * There is no default number picker as part of Material-UI.
@@ -41,8 +43,12 @@ class Date extends React.Component {
                     onDismiss={null}
                     value={value}
                     disabled={this.props.form.readonly}
-                    style={this.props.form.style || {width: '100%'}}/>
-
+                    style={this.props.form.style || {width: '90%', display: 'inline-block'}}/>
+                <IconButton ref="button"
+                    onClick={() => this.props.onChangeValidate("")}
+                    style={{position: 'relative', display: 'inline-block', top: '6px',right: '4px', padding: '0', width: '24px', height: '24px'}}>
+                    <Clear />
+                </IconButton>
             </div>
         );
     }

--- a/src/Number.js
+++ b/src/Number.js
@@ -29,6 +29,10 @@ class Number extends React.Component {
         return !isNaN(parseFloat(n)) && isFinite(n);
     }
 
+    isEmpty(n) {
+        return (!n || 0 === n.length);
+    }
+
     /**
      * Prevent the field from accepting non-numeric characters.
      * @param e
@@ -39,8 +43,12 @@ class Number extends React.Component {
                 lastSuccessfulValue: e.target.value
             });
             this.props.onChangeValidate(e);
+        } else if (this.isEmpty(e.target.value)) {
+            this.setState({
+                lastSuccessfulValue: e.target.value
+            });
         } else {
-                this.refs.numberField.value = this.state.lastSuccessfulValue;
+            this.refs.numberField.value = this.state.lastSuccessfulValue;
         }
     }
 

--- a/src/Number.js
+++ b/src/Number.js
@@ -60,7 +60,7 @@ class Number extends React.Component {
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
-                    errorText={this.props.error}
+                    errorText={this.props.error || this.props.errorText}
                     onChange={this.preValidationCheck}
                     value={this.state.lastSuccessfulValue}
                     ref="numberField"

--- a/src/Number.js
+++ b/src/Number.js
@@ -47,6 +47,7 @@ class Number extends React.Component {
             this.setState({
                 lastSuccessfulValue: e.target.value
             });
+            this.props.onChangeValidate(e);
         } else {
             this.refs.numberField.value = this.state.lastSuccessfulValue;
         }

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -33,12 +33,6 @@ class SchemaForm extends React.Component {
 
     constructor(props) {
         super(props);
-        this.onChange = this.onChange.bind(this);
-    }
-
-    onChange(key, val, type) {
-        //console.log('SchemaForm.onChange', key, val);
-        this.props.onModelChange(key, val, type);
     }
 
     builder(form, model, index, onChange, mapper, errors) {
@@ -61,13 +55,14 @@ class SchemaForm extends React.Component {
 
     render() {
         let merged = utils.merge(this.props.schema, this.props.form, this.props.ignore, this.props.option);
+
         //console.log('SchemaForm merged = ', JSON.stringify(merged, undefined, 2));
         let mapper = this.mapper;
         if(this.props.mapper) {
             mapper = _.merge(this.mapper, this.props.mapper);
         }
         let forms = merged.map(function(form, index) {
-            return this.builder(form, this.props.model, index, this.onChange, mapper, this.props.errors);
+            return this.builder(form, this.props.model, index, this.props.onModelChange, mapper, this.props.errors);
         }.bind(this));
 
         return (

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -49,7 +49,7 @@ class SchemaForm extends React.Component {
           return null;
         }
 
-        if(form.condition && eval(form.condition) === false) {
+        if(form.condition && utils.safeEval(form.condition, {model}) === false) {
           return null;
         }
 

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -41,7 +41,7 @@ class SchemaForm extends React.Component {
         this.props.onModelChange(key, val, type);
     }
 
-    builder(form, model, index, onChange, mapper) {
+    builder(form, model, index, onChange, mapper, errors) {
         var type = form.type;
         let Field = this.mapper[type];
         if(!Field) {
@@ -54,7 +54,9 @@ class SchemaForm extends React.Component {
         }
 
         const key = form.key && form.key.join(".") || index;
-        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder}/>
+
+        let error = (key in errors)? errors[key] : null;
+        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder} errorText={error}/>
     }
 
     render() {
@@ -65,7 +67,7 @@ class SchemaForm extends React.Component {
             mapper = _.merge(this.mapper, this.props.mapper);
         }
         let forms = merged.map(function(form, index) {
-            return this.builder(form, this.props.model, index, this.onChange, mapper);
+            return this.builder(form, this.props.model, index, this.onChange, mapper, this.props.errors);
         }.bind(this));
 
         return (

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -48,10 +48,13 @@ class SchemaForm extends React.Component {
           console.log('Invalid field: \"' + form.key[0] + '\"!');
           return null;
         }
+
         if(form.condition && eval(form.condition) === false) {
           return null;
         }
-        return <Field model={model} form={form} key={index} onChange={onChange} mapper={mapper} builder={this.builder}/>
+
+        const key = form.key && form.key.join(".") || index;
+        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder}/>
     }
 
     render() {

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -36,9 +36,9 @@ class SchemaForm extends React.Component {
         this.onChange = this.onChange.bind(this);
     }
 
-    onChange(key, val) {
+    onChange(key, val, type) {
         //console.log('SchemaForm.onChange', key, val);
-        this.props.onModelChange(key, val);
+        this.props.onModelChange(key, val, type);
     }
 
     builder(form, model, index, onChange, mapper) {

--- a/src/Text.js
+++ b/src/Text.js
@@ -7,14 +7,14 @@ import TextField from 'material-ui/TextField';
 
 class Text extends React.Component {
     render() {
-        //console.log('Text props', this.props.form.readonly);
+        //console.log('Text props', this.props);
         return (
             <div className={this.props.form.htmlClass}>
                 <TextField
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
-                    errorText={this.props.error}
+                    errorText={this.props.error || this.props.errorText}
                     onChange={this.props.onChangeValidate}
                     defaultValue={this.props.value}
                     disabled={this.props.form.readonly}

--- a/src/TextArea.js
+++ b/src/TextArea.js
@@ -17,7 +17,7 @@ class TextArea extends React.Component {
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
                     onChange={this.props.onChangeValidate}
-                    errorText={this.props.error}
+                    errorText={this.props.error || this.props.errorText}
                     defaultValue={this.props.value}
                     multiLine={true}
                     rows={this.props.form.rows}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import _ from'lodash';
+import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
 
@@ -24,22 +24,15 @@ var enumToTitleMap = function(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function(titleMap, originalEnum) {
-    if (!_.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function(value) {
-                canonical.push({name: titleMap[value], value: value});
-            });
-        } else {
-            for(var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({name: k, value: titleMap[k]});
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum)
+        return titleMap;
+
+    const canonical = [];
+    const _enum = (Object.keys(titleMap).length == 0)? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,17 @@
 import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
+import notevil from 'notevil';
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    try {
+        const scope_safe = _.cloneDeep(scope);
+        return notevil(condition, scope_safe);
+    } catch (error) {
+        return undefined
+    }
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -600,5 +611,6 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -462,7 +462,7 @@ function merge(schema, form, ignore, options, readonly) {
     }));
 }
 
-function selectOrSet(projection, obj, valueToSet) {
+function selectOrSet(projection, obj, valueToSet, type) {
     //console.log('selectOrSet', projection, obj, valueToSet);
     var numRe = /^\d+$/;
 
@@ -482,6 +482,14 @@ function selectOrSet(projection, obj, valueToSet) {
         typeof obj[parts[0]] === 'undefined') {
         // We need to look ahead to check if array is appropriate
         obj[parts[0]] = parts.length > 2 && numRe.test(parts[1]) ? [] : {};
+    }
+
+    if (typeof type !== 'undefined' &&
+        ['number','integer'].indexOf(type) > -1 &&
+        typeof valueToSet === 'undefined') {
+        // number or integer can undefined
+        obj[parts[0]] = valueToSet;
+        return obj;
     }
 
     var value = obj[parts[0]];


### PR DESCRIPTION
# Errors injection

It provides the possibility to pass error messages for our `SchemaForm`, useful if we want to perform some API validations and integrate the error messages with our forms.

This do not overrides internal validator errors, the passed error message just appears in case that our local validation do not raise any error message for the related field.

The way to achieve it is passing the new property `errors` at definition time:
```
const errors = {
  "step1.owner.vat": [
    "Provided VAT is not correct."
  ],
  "step1.owner.email": [
    "E-mail is mandatory, please define it."
  ]
}

const form = (
    <SchemaForm
        schema={schema}
        form={form}
        model={model}
        onModelChange={this.onModelChange}
        errors={errors}
    />
)
```

--------

Related to the errors injection, the `Checkbox` component has been improved to achieve a way to display an error text in a quite similar way that is done for the other components.

![checkbox_error](https://user-images.githubusercontent.com/8709244/41397519-c7484650-6fb4-11e8-85a0-5a9db4cb89fb.png)

### Fixed issues

Fix #92 Possibility to inject validation errros 
Fix  #96 Checkbox errors management
