### PR TITLE
use npm to run jest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}
-          - v1-dependencies
+          - v1-dependencies-
       - run: npm install jest-cli
       - run: npm run test
 workflows:

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
     "@material-ui/icons": ">2.0.1"
   },
   "scripts": {
-    "lint": "eslint src",
     "preversion": "webpack -p && git add dist",
     "prepublishOnly": "rimraf lib && NODE_ENV=production babel src -d lib",
-    "test": "npm run lint && jest"
+    "lint": "eslint src",
+    "test": "jest"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
Splits `test` script into `lint` and `test` so that they can be reported separately by circleci

@stevehu Can you turn on CircleCI for this repo?  You should be able to do that from
https://circleci.com/add-projects/gh/networknt -> Setup Project -> Start Building
