### PR TITLE
fix lint error about missing display name

### DIFF
--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -2,7 +2,7 @@
 import React from 'react';
 var utils = require('./utils');
 
-export default (ComposedComponent, defaultProps = {}) => class extends React.Component {
+export default (ComposedComponent, defaultProps = {}) => class Composed extends React.Component {
 
     constructor(props) {
         super(props);


### PR DESCRIPTION
eslint was erroring as
```
react-schema-form/src/ComposedComponent.js
  5:58  error  Component definition is missing display name  react/display-name
```

this fixes it by trivially giving the class a name