### PR TITLE
Fixes Validation Errors not Showing

### DIFF
--- a/src/ComposedComponent.js
+++ b/src/ComposedComponent.js
@@ -42,8 +42,8 @@ export default (ComposedComponent, defaultProps = {}) => class Composed extends 
         let validationResult = utils.validate(nextProps.form, value);
         return {
             value,
-            valid: !!(validationResult.valid || !value),
-            error: !validationResult.valid && value ? validationResult.error.message : null
+            valid: validationResult.valid,
+            error: !validationResult.valid ? validationResult.error.message : null
         };
     }
 

--- a/src/__tests__/ComposedComponent-test.js
+++ b/src/__tests__/ComposedComponent-test.js
@@ -40,4 +40,35 @@ describe('ComposedComponent', function () {
 
     expect(result.props.value).toEqual('steeve');
   });
+
+  it('shows an error when there is an error', function () {
+    const renderer = new ShallowRenderer();
+    var cfg = {
+        form: {
+            key: ['name'],
+            required: true,
+            schema: {
+                title: 'name',
+                type: 'String',
+            },
+            type: 'text',
+            title: 'name',
+        },
+        model: {name: ''},
+        mapper: {}
+    };
+
+    var Composed = ComposedComponent(Text);
+
+    renderer.render(
+      <Composed
+        form={cfg.form}
+        model={cfg.model}
+        mapper={cfg.mapper}
+      />);
+
+    var result = renderer.getRenderOutput();
+
+    expect(result.props.error).toEqual('Missing required property: name');
+  });
 });


### PR DESCRIPTION
As seen here: https://github.com/networknt/react-schema-form/blob/0.6.0/src/ComposedComponent.js#L45 everytime new props are received the validation state gets overwritten irrespective of there being an error or not