### PR TITLE
Pass form in scope to condition evaluation

### DIFF
--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -82,7 +82,7 @@ class SchemaForm extends Component<Props> {
         // Apply conditionals to review if this field must be rendered
         if (
             form.condition &&
-            utils.safeEval(form.condition, { model }) === false
+            utils.safeEval(form.condition, { model, form }) === false
         ) {
             return null;
         }

--- a/src/__tests__/ConditionalCapture-test.js
+++ b/src/__tests__/ConditionalCapture-test.js
@@ -25,6 +25,20 @@ const cfg = {
             date: {
                 title: "Date",
                 type: "object"
+            },
+            array: {
+                type: "array",
+                items: {
+                    type: "object",
+                    properties: {
+                        switch: {
+                            "type": "boolean"
+                        },
+                        conditional: {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         required: ["name", "date"]
@@ -78,5 +92,56 @@ describe("Composed component test", () => {
         );
         // here a date input is not expected cause condition is falsy
         expect(display.find("input").length).toEqual(1);
+    });
+    it("The arrays with condition :", () => {
+        const newForm = [
+            "name",
+            {
+                key: "array",
+                type: "array",
+                items: [
+                    "array[].switch",
+                    {
+                        key: "array[].conditional",
+                        condition: "model.array[form.key[1]].switch"
+                    }
+                ]
+            }
+        ];
+
+        let model = {
+            name: "some",
+            array: [
+                {
+                    switch: true
+                },
+                {
+                    switch: false
+                }
+            ]
+        };
+
+        let display = render(
+            <SchemaForm form={newForm} schema={cfg.schema} model={model} />
+        );
+        // Should show 'conditional' field in only one element of the array
+        expect(display.find("input").length).toEqual(4);
+
+        model.array[1].switch = true;
+
+        display = render(
+            <SchemaForm form={newForm} schema={cfg.schema} model={model} />
+        );
+        // Should show 'conditional' field in both elements of the array
+        expect(display.find("input").length).toEqual(5);
+
+        model.array[0].switch = false;
+        model.array[1].switch = false;
+
+        display = render(
+            <SchemaForm form={newForm} schema={cfg.schema} model={model} />
+        );
+        // Should not show 'conditional' field in either elements of the array
+        expect(display.find("input").length).toEqual(3);
     });
 });


### PR DESCRIPTION
If you have a conditional element in an array you need to know the key for the element if you base the condition on another element in the object.

Fixes issue #142 