### PR TITLE
Allow additional contexts to be passed to be used in evaluation of 'condition' property

### DIFF
--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -135,10 +135,11 @@ function (_Component) {
 
   _createClass(SchemaForm, [{
     key: "builder",
-    value: function builder(form, model, index, mapper, onChange, _builder, evalContext) {
+    value: function builder(form, model, index, mapper, onChange, _builder) {
       var _this$props = this.props,
           errors = _this$props.errors,
-          showErrors = _this$props.showErrors;
+          showErrors = _this$props.showErrors,
+          evalContext = _this$props.evalContext;
       var Field = this.mapper[form.type];
 
       if (!Field) {
@@ -146,10 +147,10 @@ function (_Component) {
       } // Apply conditionals to review if this field must be rendered
 
 
-      if (form.condition && _utils["default"].safeEval(form.condition, _objectSpread({
+      if (form.condition && !_utils["default"].safeEval(form.condition, _objectSpread({
         model: model,
         form: form
-      }, evalContext)) === false) {
+      }, evalContext))) {
         return null;
       }
 

--- a/lib/__tests__/ConditionalCapture-test.js
+++ b/lib/__tests__/ConditionalCapture-test.js
@@ -18,6 +18,10 @@ var cfg = {
     key: "date",
     type: "date",
     condition: 'model.name !== "" && model.name !== undefined'
+  }, {
+    key: "secretDate",
+    type: "date",
+    condition: "roles && roles.includes('canSeeSecrets')"
   }],
   schema: {
     type: "object",
@@ -28,6 +32,10 @@ var cfg = {
         minLength: 3
       },
       date: {
+        title: "Date",
+        type: "object"
+      },
+      secretDate: {
         title: "Date",
         type: "object"
       },
@@ -142,5 +150,20 @@ describe("Composed component test", function () {
     })); // Should not show 'conditional' field in either elements of the array
 
     expect(display.find("input").length).toEqual(3);
+  });
+  it("Condition with additonal context:", function () {
+    var display = (0, _enzyme.render)(_react["default"].createElement(_SchemaForm["default"], {
+      form: cfg.form,
+      schema: cfg.schema,
+      model: cfg.model,
+      evalContext: {
+        roles: ['canSeeSecrets']
+      }
+    })); // Output must have three inputs
+
+    expect(display.find("input").length).toEqual(3); // And second & third inputs type have to be of type 'date'
+
+    expect(display.find("input")[1].attribs.type).toEqual("date");
+    expect(display.find("input")[2].attribs.type).toEqual("date");
   });
 });

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -32,7 +32,8 @@ type Props = {
     className: any,
     mapper: any,
     localization?: Localization,
-    showErrors?: boolean
+    showErrors?: boolean,
+    evalContext: any,
 };
 
 const formatDate = (date: string | Date) => {
@@ -96,8 +97,8 @@ class SchemaForm extends Component<Props> {
         };
     };
 
-    builder(form, model, index, mapper, onChange, builder, evalContext) {
-        const { errors, showErrors } = this.props;
+    builder(form, model, index, mapper, onChange, builder) {
+        const { errors, showErrors, evalContext } = this.props;
         const Field = this.mapper[form.type];
         if (!Field) {
             return null;
@@ -106,8 +107,7 @@ class SchemaForm extends Component<Props> {
         // Apply conditionals to review if this field must be rendered
         if (
             form.condition &&
-            utils.safeEval(form.condition, { model, form, ...evalContext }) ===
-                false
+            !utils.safeEval(form.condition, { model, form, ...evalContext })
         ) {
             return null;
         }
@@ -118,18 +118,18 @@ class SchemaForm extends Component<Props> {
 
         return (
             <Field
-                model={model}
-                form={form}
-                key={key}
-                onChange={onChange}
-                setDefault={this.setDefault}
-                mapper={mapper}
-                builder={builder}
-                errorText={error}
-                localization={this.getLocalization()}
-                showErrors={showErrors}
-            />
-        );
+        model={model}
+        form={form}
+        key={key}
+        onChange={onChange}
+        setDefault={this.setDefault}
+        mapper={mapper}
+        builder={builder}
+        errorText={error}
+        localization={this.getLocalization()}
+        showErrors={showErrors}
+        />
+    );
     }
 
     render() {

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -33,7 +33,7 @@ type Props = {
     mapper: any,
     localization?: Localization,
     showErrors?: boolean,
-    evalContext: any,
+    evalContext: any
 };
 
 const formatDate = (date: string | Date) => {
@@ -118,18 +118,18 @@ class SchemaForm extends Component<Props> {
 
         return (
             <Field
-        model={model}
-        form={form}
-        key={key}
-        onChange={onChange}
-        setDefault={this.setDefault}
-        mapper={mapper}
-        builder={builder}
-        errorText={error}
-        localization={this.getLocalization()}
-        showErrors={showErrors}
-        />
-    );
+                model={model}
+                form={form}
+                key={key}
+                onChange={onChange}
+                setDefault={this.setDefault}
+                mapper={mapper}
+                builder={builder}
+                errorText={error}
+                localization={this.getLocalization()}
+                showErrors={showErrors}
+            />
+        );
     }
 
     render() {

--- a/src/__tests__/ConditionalCapture-test.js
+++ b/src/__tests__/ConditionalCapture-test.js
@@ -12,6 +12,11 @@ const cfg = {
             key: "date",
             type: "date",
             condition: 'model.name !== "" && model.name !== undefined'
+        },
+        {
+            key: "secretDate",
+            type: "date",
+            condition: "roles && roles.includes('canSeeSecrets')"
         }
     ],
     schema: {
@@ -23,6 +28,10 @@ const cfg = {
                 minLength: 3
             },
             date: {
+                title: "Date",
+                type: "object"
+            },
+            secretDate: {
                 title: "Date",
                 type: "object"
             },
@@ -143,5 +152,17 @@ describe("Composed component test", () => {
         );
         // Should not show 'conditional' field in either elements of the array
         expect(display.find("input").length).toEqual(3);
+    });
+
+    it("Condition with additonal context:", () => {
+        const display = render(
+            <SchemaForm form={cfg.form} schema={cfg.schema} model={cfg.model} evalContext={{roles: ['canSeeSecrets']}}/>
+        );
+
+        // Output must have three inputs
+        expect(display.find("input").length).toEqual(3);
+        // And second & third inputs type have to be of type 'date'
+        expect(display.find("input")[1].attribs.type).toEqual("date");
+        expect(display.find("input")[2].attribs.type).toEqual("date");
     });
 });

--- a/src/__tests__/ConditionalCapture-test.js
+++ b/src/__tests__/ConditionalCapture-test.js
@@ -156,7 +156,12 @@ describe("Composed component test", () => {
 
     it("Condition with additonal context:", () => {
         const display = render(
-            <SchemaForm form={cfg.form} schema={cfg.schema} model={cfg.model} evalContext={{roles: ['canSeeSecrets']}}/>
+            <SchemaForm
+                form={cfg.form}
+                schema={cfg.schema}
+                model={cfg.model}
+                evalContext={{ roles: ["canSeeSecrets"] }}
+            />
         );
 
         // Output must have three inputs


### PR DESCRIPTION
My use case for this is that I want to be able to pass a user's roles into the form to hide parts to which they should not have access. I also need to pass the current 'mode' so for example the save button only shows in edit mode.